### PR TITLE
add-missing-imports-visual-studio

### DIFF
--- a/Utils/VS/Utils.vcxproj
+++ b/Utils/VS/Utils.vcxproj
@@ -33,6 +33,8 @@
     <ClCompile Include="..\GLTexture2D.cpp" />
     <ClCompile Include="..\GLTexture3D.cpp" />
     <ClCompile Include="..\GLTextureCube.cpp" />
+    <ClCompile Include="..\GLFramebuffer.cpp" />
+    <ClCompile Include="..\GLDepthBuffer.cpp" />
     <ClCompile Include="..\Grid2D.cpp" />
     <ClCompile Include="..\ImageLoader.cpp" />
     <ClCompile Include="..\OBJFile.cpp" />
@@ -57,6 +59,8 @@
     <ClInclude Include="..\GLTexture2D.h" />
     <ClInclude Include="..\GLTexture3D.h" />
     <ClInclude Include="..\GLTextureCube.h" />
+    <ClInclude Include="..\GLFramebuffer.h" />
+    <ClInclude Include="..\GLDepthBuffer.h" />
     <ClInclude Include="..\Grid2D.h" />
     <ClInclude Include="..\Mat4.h" />
     <ClInclude Include="..\OBJFile.h" />

--- a/Utils/VS/Utils.vcxproj.filters
+++ b/Utils/VS/Utils.vcxproj.filters
@@ -54,6 +54,12 @@
     <ClCompile Include="..\GLTextureCube.cpp">
       <Filter>Quelldateien</Filter>
     </ClCompile>
+    <ClCompile Include="..\GLFramebuffer.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
+    <ClCompile Include="..\GLDepthBuffer.cpp">
+      <Filter>Quelldateien</Filter>
+    </ClCompile>
     <ClCompile Include="..\Grid2D.cpp">
       <Filter>Quelldateien</Filter>
     </ClCompile>
@@ -111,6 +117,12 @@
       <Filter>Headerdateien</Filter>
     </ClInclude>
     <ClInclude Include="..\GLTextureCube.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GLFramebuffer.h">
+      <Filter>Headerdateien</Filter>
+    </ClInclude>
+    <ClInclude Include="..\GLDepthBuffer.h">
       <Filter>Headerdateien</Filter>
     </ClInclude>
     <ClInclude Include="..\Grid2D.h">


### PR DESCRIPTION
Missing imports in Visual Studio cause errors when running the Skeleton code for Assignment 6


Visual Studio 2022
Visual C++ platform toolset v142