### PR TITLE
Fix fehlerhafte Abgaben von Übungen

### DIFF
--- a/.zip_config
+++ b/.zip_config
@@ -1,0 +1,2 @@
+# first line is ignored; add first and lastname to be used in the creation of the zip file; example: Lars Gilhaus
+Firstname Lastname

--- a/01_HelloGL/.zip_config
+++ b/01_HelloGL/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+main.cpp

--- a/02_Triforce/.zip_config
+++ b/02_Triforce/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+

--- a/02_Triforce/.zip_config
+++ b/02_Triforce/.zip_config
@@ -1,2 +1,2 @@
 # first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
-
+main.cpp res/shaders/fragmentShader.frag res/shaders/vertexShader.vert

--- a/03_HelloShading/.zip_config
+++ b/03_HelloShading/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+

--- a/04_Textureing/.zip_config
+++ b/04_Textureing/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+

--- a/05_Shadows/.zip_config
+++ b/05_Shadows/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+

--- a/06_Reflections/.zip_config
+++ b/06_Reflections/.zip_config
@@ -1,0 +1,2 @@
+# first line ignored; add files to be included in zip with whitespace between them; example: foo.cpp bar.cpp baz.cpp
+

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -16,12 +16,14 @@ usage() {
         exit 1
 }
 
+# utility for logging
 log() {
         if [ ${SILENT} -eq 0 ]; then
                 echo "$1"
         fi
 }
 
+# read call options
 while getopts ":rns" o; do
         case "${o}" in
                 r)
@@ -42,11 +44,13 @@ done
 config_name=".zip_config"
 lines_read=0
 zip_name=""
-
 full_name=""
+
+# read name-config file
 while read line; do
         lines_read=$(($lines_read+1))
         if [ ${lines_read} -eq 1 ]; then
+                # ignore first line
                 continue
         elif [ ${lines_read} -eq 2 ]; then
                 # split line and fill zip_name in correct format
@@ -55,10 +59,12 @@ while read line; do
                         zip_name="${zip_name}_${name}"
                 done
         else
-                exit 1
+                # only accept second line
+                break
         fi
 done < "${PWD}/${config_name}"
 
+# check if actual content was read
 if [ -z ${zip_name} ]; then
         echo "Could not find a name within file <${PWD}/${config_name}>" 1>&2; exit 1;
 fi
@@ -68,25 +74,31 @@ log "Found name <${full_name}> in file <${PWD}/${config_name}>"
 log "Processing folders.."
 log ""
 
+# continue iterating over task folders
 for dir in [0-9][0-9]* ; do
         full_path="${PWD}/${dir}"
 
         log "  ${full_path}:"
 
         files_cfg="${full_path}/${config_name}"
+
+        # check if zip-config exists within task folder
         if ! test -f ${files_cfg}; then
                 log "    - No config file found in here, continuing with next folder.."
                 log ""
                 continue
         fi
 
-        # config file exists
         lines_read=0
+
+        # read zip-config of task folder
         while read line; do
                 lines_read=$(($lines_read+1))
                 if [ ${lines_read} -eq 1 ]; then
+                        # ignore first line
                         continue
                 elif [ ${lines_read} -eq 2 ]; then
+                        # trim leading 0s
                         if [ ${dir:0:1} -eq 0 ]; then
                                 zip_name_full="a${dir:1:1}${zip_name}.zip"
                         else
@@ -99,6 +111,8 @@ for dir in [0-9][0-9]* ; do
                         # Only create zip, if not a dry run and file does not exist, or REPLACE flag is set
                         if [ ${DRY_RUN} -eq 0 ] && [ ! -f ${full_path}/${zip_name_full} ] || [ ${REPLACE} -eq 1 ]; then
                                 log "    - Trying to execute: zip ${full_path}/${zip_name_full} ${full_path}/${line}" 
+
+                                # actual command execution using zip
                                 zip ${full_path}/${zip_name_full} ${full_path}/${line}
                         else
                                 if [ ${DRY_RUN} -eq 1 ]; then
@@ -110,6 +124,7 @@ for dir in [0-9][0-9]* ; do
                                 fi
                         fi
                 else
+                        # only accept second line
                         break
                 fi
         done < ${files_cfg}

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -116,7 +116,7 @@ for dir in [0-9][0-9]* ; do
                                 zip ${full_path}/${zip_name_full} ${full_path}/${line}
                         else
                                 if [ ${DRY_RUN} -eq 1 ]; then
-                                        log "    - -r flag was set; no zip file was created!"
+                                        log "    - -n flag was set; no zip file was created!"
                                 fi
 
                                 if [ ${REPLACE} -eq 0 ] && [ -f ${full_path}/${zip_name_full} ] && [ ${DRY_RUN} -eq 0 ]; then

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+
+# parse parameters
+REPLACE=0
+DRY_RUN=0
+SILENT=0
+
+# basic usage of script
+usage() { 
+        echo "Usage: $0 [-r] [-n] [-s]" 1>&2;
+        echo ""
+        echo " where -r stands for replacing archives"
+        echo "   and -n stands for explicitly not executing *any* changes (dry run)"
+        echo "   and -s stands for silent, which suppresses most print outs"
+
+        exit 1
+}
+
+log() {
+        if [ ${SILENT} -eq 0 ]; then
+                echo "$1"
+        fi
+}
+
+while getopts ":rns" o; do
+        case "${o}" in
+                r)
+                        REPLACE=1
+                        ;;
+                n)
+                        DRY_RUN=1
+                        ;;
+                s)
+                        SILENT=1
+                        ;;
+                *)
+                        usage
+                        ;;
+        esac
+done
+
+config_name=".zip_config"
+lines_read=0
+zip_name=""
+
+full_name=""
+while read line; do
+        lines_read=$(($lines_read+1))
+        if [ ${lines_read} -eq 1 ]; then
+                continue
+        elif [ ${lines_read} -eq 2 ]; then
+                # split line and fill zip_name in correct format
+                full_name=${line}
+                for name in $line; do
+                        zip_name="${zip_name}_${name}"
+                done
+        else
+                exit 1
+        fi
+done < "${PWD}/${config_name}"
+
+if [ -z ${zip_name} ]; then
+        echo "Could not find a name within file <${PWD}/${config_name}>" 1>&2; exit 1;
+fi
+
+log "Found name <${full_name}> in file <${PWD}/${config_name}>"
+
+log "Processing folders.."
+log ""
+
+for dir in [0-9][0-9]* ; do
+        full_path="${PWD}/${dir}"
+
+        log "  ${full_path}:"
+
+        files_cfg="${full_path}/${config_name}"
+        if ! test -f ${files_cfg}; then
+                log "    - No config file found in here, continuing with next folder.."
+                log ""
+                continue
+        fi
+
+        # config file exists
+        lines_read=0
+        while read line; do
+                lines_read=$(($lines_read+1))
+                if [ ${lines_read} -eq 1 ]; then
+                        continue
+                elif [ ${lines_read} -eq 2 ]; then
+                        if [ ${dir:0:1} -eq 0 ]; then
+                                zip_name_full="a${dir:1:1}${zip_name}.zip"
+                        else
+                                zip_name_full="a${dir:0:2}${zip_name}.zip"
+                        fi
+                        
+                        log "    - Zip filename determined: <${zip_name_full}>"
+                        log "    - To-be-zipped files: <${line}>"
+
+                        # Only create zip, if not a dry run and file does not exist, or REPLACE flag is set
+                        if [ ${DRY_RUN} -eq 0 ] && [ ! -f ${full_path}/${zip_name_full} ] || [ ${REPLACE} -eq 1 ]; then
+                                log "    - Trying to execute: zip ${full_path}/${zip_name_full} ${full_path}/${line}" 
+                                zip ${full_path}/${zip_name_full} ${full_path}/${line}
+                        else
+                                if [ ${DRY_RUN} -eq 1 ]; then
+                                        log "    - -r flag was set; no zip file was created!"
+                                fi
+
+                                if [ ${REPLACE} -eq 0 ] && [ -f ${full_path}/${zip_name_full} ] && [ ${DRY_RUN} -eq 0 ]; then
+                                        log "    - Replace flag not set; zip file was *not* overriden!"
+                                fi
+                        fi
+                else
+                        break
+                fi
+        done < ${files_cfg}
+        log ""
+done

--- a/create_zip.sh
+++ b/create_zip.sh
@@ -108,12 +108,19 @@ for dir in [0-9][0-9]* ; do
                         log "    - Zip filename determined: <${zip_name_full}>"
                         log "    - To-be-zipped files: <${line}>"
 
+                        # create file-string for zip command
+                        files=""
+                        for file in ${line}; do
+                                files="${files} ${full_path}/${file}"
+                        done
+                        files=${files:1}
+
                         # Only create zip, if not a dry run and file does not exist, or REPLACE flag is set
-                        if [ ${DRY_RUN} -eq 0 ] && [ ! -f ${full_path}/${zip_name_full} ] || [ ${REPLACE} -eq 1 ]; then
-                                log "    - Trying to execute: zip ${full_path}/${zip_name_full} ${full_path}/${line}" 
+                        if [ ${DRY_RUN} -eq 0 ] && ([ ! -f ${full_path}/${zip_name_full} ] || [ ${REPLACE} -eq 1 ]); then
+                                log "    - Trying to execute: zip -j ${full_path}/${zip_name_full} ${files}" 
 
                                 # actual command execution using zip
-                                zip ${full_path}/${zip_name_full} ${full_path}/${line}
+                                zip -j ${full_path}/${zip_name_full} ${files}
                         else
                                 if [ ${DRY_RUN} -eq 1 ]; then
                                         log "    - -n flag was set; no zip file was created!"


### PR DESCRIPTION
@JensDerKrueger:

Um das Problem der fehlerhaften Benennung oder Inklusion der Dateien zu beheben, könnte das folgende Bash-script verwendet werden. Dieses kümmert sich um die o.g. Probleme und erfordert von den Studierenden lediglich eine einmalige Eingabe des eigenen Vor- und Nachnamens. Die Angabe darüber, welche Dateien inkludiert werden sollen, kann vorab eingestellt werden (Config-File je Aufgabenordner).

Grundsätzlich funktionert das Skript so, dass es die Config-File (`AIS/.zip_config`) im Ordner `AIS/` liest und von dort den Namen entnimmt. Danach iteriert das Skript über alle Ordner die mit einer zweistelligen Zahl beginnen (= die Aufgaben) und schaut innerhalb dieser Ordner nach einer weiteren Config-File (Bspw. `AIS/01_HelloGL/zip_config`), die die zu inkludierenden Dateien festlegt (diese können je nach Aufgabe variieren). Zusätzlich wird aus der Nummer des Ordners die Nummer für die Abgabe (ohne führende 0) entnommen.
Anschließend werden alle Informationen zusammengeführt und ein `zip`-Aufruf gestartet.

Da ich auch das Angeben der zu zippenden Aufgabe aus der Verantwortung der Studierenden nehmen wollte, generiert dieses Skript je Aufruf für alle Ordner die Zip-Datei. Um eine dort vorhandene Zip-Datei zu überschreiben, muss jedoch das Flag `-r` (replace) angegeben werden.
Darüber hinaus gibt es noch die Flags `-n` (dry-run, also alles ausführen, bis auf den `zip`-Aufruf) und `-s` (silent, für die Unterdrückung der Ausgaben auf der Konsole; exklusive der Ausgabe von `zip` selbst). Gibt man eine Option an, die es nicht gibt, werden die möglichen Optionen und deren Bedeutung geprintet.

Aktuell gibt es nur für die erste Aufgabe eine Angabe der zu inkludierenden Dateien (`AIS/01_HelloGL/.zip_config`), für die nächsten Aufgaben muss die jeweilige Config-File noch angepasst werden (`AIS/02_Triforce/.zip_config`, `AIS/03_HelloShading/.zip_config`, ...).


Wie sieht ein Aufruf aus?
Aufgerufen werden muss das Skript aus dem Ordner `AIS/` selbst (also AIS muss das working directory sein!). Es benötigt keine weiteren Argumente, jedoch können optional Flags gesetzt werden.

Aufruf mit Flag `-n` gesetzt:
<img width="565" height="601" alt="image" src="https://github.com/user-attachments/assets/3960b43b-14d8-4c56-b073-76a3dc8b0892" />

Normaler Aufruf, ganz ohne Flags:
<img width="1020" height="707" alt="image" src="https://github.com/user-attachments/assets/5bfaa821-e2f5-405d-bd38-8e31db889526" />

Erneuter Versuch, ohne `-r`-Flag zu benutzen:
<img width="570" height="606" alt="image" src="https://github.com/user-attachments/assets/35040b6e-01e2-4009-9994-bf4ca3b70dff" />

Und dann noch einmal mit `-r`-Flag gesetzt:
<img width="1022" height="707" alt="image" src="https://github.com/user-attachments/assets/66b9c96d-ce14-4954-b562-2122c59cd3d0" />
